### PR TITLE
fix(libcontainer): combine multi error when create container failed

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -60,11 +60,14 @@ impl ContainerBuilderImpl {
             Err(outer) => {
                 // Only the init container should be cleaned up in the case of
                 // an error.
+                let mut errors = vec![outer];
                 if matches!(self.container_type, ContainerType::InitContainer) {
-                    self.cleanup_container()?;
+                    if let Err(e) = self.cleanup_container() {
+                        errors.push(e);
+                    }
                 }
 
-                Err(outer)
+                Err(LibcontainerError::MultiError(errors.into()))
             }
         }
     }

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -101,28 +101,21 @@ pub enum ErrInvalidSpec {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub struct CreateContainerError {
-    #[source]
-    run_error: Box<LibcontainerError>,
-    cleanup_error: Option<Box<LibcontainerError>>,
-}
+pub struct CreateContainerError(Box<LibcontainerError>, Option<Box<LibcontainerError>>);
 
 impl CreateContainerError {
     pub(crate) fn new(
         run_error: LibcontainerError,
         cleanup_error: Option<LibcontainerError>,
     ) -> Self {
-        Self {
-            run_error: Box::new(run_error),
-            cleanup_error: cleanup_error.map(Box::new),
-        }
+        Self(Box::new(run_error), cleanup_error.map(Box::new))
     }
 }
 
 impl std::fmt::Display for CreateContainerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "failed to create container: {}", self.run_error)?;
-        if let Some(cleanup_err) = &self.cleanup_error {
+        write!(f, "failed to create container: {}", self.0)?;
+        if let Some(cleanup_err) = &self.1 {
             write!(f, ". error during cleanup: {}", cleanup_err)?;
         }
         Ok(())

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -127,8 +127,9 @@ impl From<Vec<LibcontainerError>> for MultiError {
 
 #[cfg(test)]
 mod tests {
-    use super::{LibcontainerError, MultiError};
     use libcgroups::common::CreateCgroupSetupError;
+
+    use super::{LibcontainerError, MultiError};
 
     #[test]
     fn test_multi_error() {


### PR DESCRIPTION
When container creation fails and triggers a cleanup process that also fails, the original creation error is overwritten by the cleanup error. This change ensures that both the primary creation error and the subsequent cleanup error are captured and reported, providing better visibility into the failure sequence.